### PR TITLE
use forEach instead of map when return value is not used (#614)

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -97,7 +97,7 @@ export async function getProjectFiles(rootDir: string = path.join('.', '/'), cal
 
     // Check if there are files that will conflict if renamed .gs to .js.
     // When pushing to Apps Script, these files will overwrite each other.
-    intersection.map((name: string) => {
+    intersection.forEach((name: string) => {
       const fileNameWithoutExt = name.slice(0, -path.extname(name).length);
       if (
         intersection.indexOf(fileNameWithoutExt + '.js') !== -1 &&


### PR DESCRIPTION
Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] `npm run test` succeeds.
- [ ] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
