### PR TITLE
Change CLASP acronym description emphasis from italics to bold in README (#826)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <a href="https://github.com/google/gts" title="Code Style: Google"><img src="https://img.shields.io/badge/code%20style-google-blueviolet.svg"/></a>
 </p>
 
-> Develop [Apps Script](https://developers.google.com/apps-script/) projects locally using clasp (*C*ommand *L*ine *A*pps *S*cript *P*rojects).
+> Develop [Apps Script](https://developers.google.com/apps-script/) projects locally using clasp (**C**ommand **L**ine **A**pps **S**cript **P**rojects).
 
 <!-- GIF bash prompt: PS1='\[\033[38;5;9m\]❤  \[$(tput sgr0)\]' -->
 <!-- Width: 888px -->

--- a/docs/esmodules.md
+++ b/docs/esmodules.md
@@ -1,0 +1,81 @@
+# ES Modules
+
+Currently, Google Apps Script does **not** support ES modules. Hence the typical `export`/`import` pattern cannot be used and will fail.
+
+One way of handling this is to use [rollup.js](https://rollupjs.org/) to bundle your project into one single JavaScript file.
+
+The trick here is to make sure not to export any functions in your entry point code, e.g. `index.ts`, _and_ to prevent any generation of export statement in the final bundle (see the custom rollup plugin in the `rollup.config.js` below).
+
+```js
+import { babel } from "@rollup/plugin-babel";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+
+const extensions = [".ts", ".js"];
+
+const preventThreeShakingPlugin = () => {
+    return {
+      name: 'no-threeshaking',
+      resolveId(id, importer) {
+        if (!importer) {
+            // let's not theeshake entry points, as we're not exporting anything in Apps Script files
+          return {id, moduleSideEffects: "no-treeshake" }
+        }
+        return null;
+      }
+    }
+  }
+
+export default {
+  input: "./src/index.ts",
+  output: {
+    dir: "build",
+    format: "esm",
+  },
+  plugins: [
+    preventThreeShakingPlugin(),
+    nodeResolve({
+      extensions,
+    }),
+    babel({ extensions, babelHelpers: "runtime" }),
+  ],
+};
+```
+
+In order to use [babel](https://babeljs.io/) to transpile the code, be sure to add a `babel.config.js` to the project:
+
+```js
+module.exports = {
+  presets: [
+    [
+      // ES features necessary for user's Node version
+      require("@babel/preset-env").default,
+      {
+        targets: {
+          node: "current",
+        },
+      },
+    ],
+    [require("@babel/preset-typescript").default],
+  ],
+};
+```
+
+In the above example, the resulting bundle created by transpiling the entry point, i.e. `./src/index.ts`, will end up as `./build/index.js`. To make sure Clasp picks the right files to push, a `.claspignore`-file must be added to the project:
+
+```ignore
+# ignore all files…
+**/**
+
+# except the extensions…
+!appsscript.json
+# and our transpiled code
+!build/*.js
+
+# ignore even valid files if in…
+.git/**
+node_modules/**
+```
+
+Now you can push using your normal `clasp push`-command!
+
+This should be enough to start developing a project using ES Modules. A complete example repo can be cloned from [atti187/esmodules](https://github.com/atti187/esmodules).

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -297,6 +297,8 @@ Here the idea is to use third party tools ([webpack](https://webpack.js.org/), [
 
 > At one of the steps above, transpilling TypeScript into JavaScript must occur (either by using TypeScript or [Babel](https://babeljs.io/)) but which precise step will be defined by the set of third party tools you choose and how you define your build chain.
 
+For an example on how this could be set up using [rollup.js](https://rollupjs.org/), see [esmodules.md](./esmodules.md).
+
 Documenting in detail any solution with third party tools is currently beyond the scope of this document. If you happen to setup such a build chain and want to share it with the community, please open an issue so that it can be reviewed and evaluated for completing the documentation.
 
 ### Apps Script Libraries and TypeScript


### PR DESCRIPTION
Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] `npm run test` succeeds.
- [ ] `npm run lint` succeeds.
- [ ] Appropriate changes to README are included in PR.
